### PR TITLE
Use the build script in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ commands into your operating system's `terminal` program.
 ```
 # <path-to-ceno> must be replaced with the path to where you installed CeNo
 cd <path-to-ceno>/ceno-node/src/
-go build client.go clientconfig.go
+./build.sh
 ./client
 ```
 


### PR DESCRIPTION
Without it, you'll get this.
```
/tmp/ceno/ceno-node/src > go build client.go clientconfig.go
# command-line-arguments
./client.go:29: undefined: ErrorCode
```