### PR TITLE
Refresh error pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ ceno-client/client
 ceno-client/FreenetCENO.tar.gz
 ceno-client/FreenetCENO
 
+# Integration and feature testing tools
+ceno-client/test/erroringlcs
+
 # Compiled CENO reader service and mock servers
 ceno-reader/reader
 ceno-reader/bundleserver

--- a/ceno-client/build.sh
+++ b/ceno-client/build.sh
@@ -22,4 +22,10 @@ cd translations
 $GOPATH/bin/goi18n *.all.json *.untranslated.json
 cd ..
 
+echo "Building feature and integration testing tools."
+cd test
+go build erroringlcs.go
+echo "  * erroringlcs - LCS that always serves an error for testing auto-refreshing."
+cd ..
+
 go build $SOURCE_FILES && echo "Compiled client successfully."

--- a/ceno-client/test/erroringlcs.go
+++ b/ceno-client/test/erroringlcs.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type ErrorCode int
+
+const INTERNAL_ERROR ErrorCode = 2140
+const ERR_MSG string = "Testing that we can serve errors and have the client auto-refresh erro pages"
+
+type ErrorResult struct {
+	ErrCode  ErrorCode
+	ErrMsg   string
+	Complete bool
+	Found    bool
+	Bundle   string
+}
+
+func lookupHandler(w http.ResponseWriter, r *http.Request) {
+	response, _ := json.Marshal(ErrorResult{
+		INTERNAL_ERROR,
+		ERR_MSG,
+		false,
+		false,
+		"",
+	})
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(response)
+}
+
+func main() {
+	http.HandleFunc("/lookup", lookupHandler)
+	fmt.Println("Running LCS on localhost:3091")
+	http.ListenAndServe(":3091", nil)
+}

--- a/ceno-client/views/error.html
+++ b/ceno-client/views/error.html
@@ -88,6 +88,14 @@ div#stack {
     <span id="report" class="colored text"><a id="reportAnchor" href="#">{{.Report}}</a></span>
   </div>
   <script type="text/javascript">
+    var shouldRefreshStr = "{{.ShouldRefresh}}";
+    if (shouldRefreshStr === "true") {
+      setTimeout(function () {
+        var url = document.getElementById('url').innerHTML;
+        window.location.href = url;
+      }, 5000);
+    }
+  
   document.getElementById('retry').addEventListener('click', function (event) {
     var url = document.getElementById('url').innerHTML;
     window.location.href = url;
@@ -107,7 +115,6 @@ div#stack {
       link += key.charAt(i);
     }
   }
-  document.getElementById('reportAnchor').setAttribute('href', 'mailto:"' + link + '"');
-  </script>
+  document.getElementById('reportAnchor').setAttribute('href', 'mailto:"' + link + '"'); </script>
 </body>
 </html>

--- a/ceno-reader/src/data.go
+++ b/ceno-reader/src/data.go
@@ -57,6 +57,39 @@ const (
 	Gigabytes = 1024 * Megabytes
 )
 
+// Types for classes of errors that might occur. Used to report errors
+// in the database.
+type ErrorClass int
+
+const (
+	NoErrorClasses = 0
+	InvalidUrl     = 1 << iota
+	NoResponse     = 1 << iota
+	Malformed      = 1 << iota
+)
+
+// Map JSON-friendly string names of error classes to their internal representation
+var ErrorClasses map[string]ErrorClass = map[string]ErrorClass{
+	"invalidUrl": InvalidUrl,
+	"noResponse": NoResponse,
+	"malformed":  Malformed,
+}
+
+// Resources that errors can be related to
+type Resource int
+
+const (
+	NoResources = 0
+	Feed        = 1 << iota
+	Article     = 1 << iota
+)
+
+// Map JSON-friendly string names of resource types to their internal representation
+var Resources map[string]Resource = map[string]Resource{
+	"feed":    Feed,
+	"article": Article,
+}
+
 // Maximum number of bytes we will allow for a bundle of a page
 const MAX_BUNDLE_SIZE ByteSize = 100 * Megabytes
 
@@ -85,6 +118,26 @@ type Item struct {
 	FeedUrl   string `json:"feedUrl"`
 	Authors   string `json:"authors"`
 	Published string `json:"published"`
+}
+
+/**
+ * Describes an error report as related to a particular resource.
+ */
+type ErrorReport struct {
+	Id            int
+	ResourceTypes Resource
+	ErrorTypes    ErrorClass
+	ErrorMessage  string
+}
+
+/**
+ * A container for JSON data to be parsed from requests to have
+ * reports generated.  This data will be converted to and from
+ * ErrorReport structures for working with the database.
+ */
+type ErrorReportMsg struct {
+	ResourceTypes []string `json:"resources"`
+	ErrorClasses  []string `json:"classes"`
 }
 
 /**

--- a/ceno-reader/src/reader.go
+++ b/ceno-reader/src/reader.go
@@ -211,6 +211,8 @@ func insertHandler(w http.ResponseWriter, r *http.Request) {
 			fmt.Println("Couldn't get items for " + feed.Url)
 			fmt.Println(itemsError)
 		} else {
+			fmt.Println(items)
+			fmt.Println("Items for " + feed.Url)
 			writeItemsErr := writeItems(feed.Url, items)
 			if writeItemsErr != nil {
 				fmt.Println("Could not write items for " + feed.Url)

--- a/ceno-reader/src/reports.go
+++ b/ceno-reader/src/reports.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"errors"
+)
+
+// Descriptions of the different classes of errors, converting from the kinds of names
+// retrieved from JSON into something human readable.
+var errorClassDescriptions map[string]string = map[string]string{
+	"invalidUrl": "A URL for which a request could not be made, because it is invalid.",
+	"noResponse": "A request that received no response, likely because the resource doesn't exist.",
+	"malformed":  "A resource was received however it contains malformed content.",
+}
+
+/**
+ * Convert the contents of a GET request for a report with certain restrictions
+ * on the types of resources of interest or the classes of errors of interest
+ * into the internal representation of those types, ready to go to the database.
+ * @param reportMsg - The contents of the request for a report
+ * @return An internal representation of the report to generate and an error if
+ * values that aren't understood were supplied.
+ */
+func ConvertErrorReport(reportMsg ErrorReportMsg) (ErrorReport, error) {
+	report := ErrorReport{-1, NoResources, NoErrorClasses, ""}
+	for _, _class := range reportMsg.ErrorClasses {
+		errorClass, found := ErrorClasses[_class]
+		if !found {
+			return nil, errors.New("No such error class " + _class)
+		} else {
+			report.ErrorClasses |= errorClass
+		}
+	}
+	for _, _type := range reportMsg.ResourceTypes {
+		resourceType, found := Resources[_type]
+		if !found {
+			return nil, errors.New("No such resource type " + _type)
+		} else {
+			report.ResourceTypes |= resourceType
+		}
+	}
+	return report, nil
+}
+
+/**
+ * Generate a textual report to describe a list of errors.
+ * @param reports - An array of errors to describe
+ */
+func WriteReport(reports []ErrorReport) string {
+	reportMsg := ""
+	for _, report := range reports {
+		// The first line looks like "Error concerns feeds, articles.\n"
+		reportMsg += "Error concerns "
+		resources := make([]string, 0)
+		for resourceName, id := range Resources {
+			if id&report.ResourceTypes != 0 {
+				resources = append(resources, resourceName+"s")
+			}
+		}
+		reportMsg += strings.Join(resources, ", ") + ".\n"
+		// Now produce a human-readable list of error categories
+		// e.g. converting "noResponse" into "A request that was not responded to"
+		reportMsg += "The categories prescribed to the error are:\n"
+		for className, id := range ErrorClasses {
+			if id&report.ErrorTypes != 0 {
+				reportMsg += "\t- " + errorClassDescriptions[className] + "\n"
+			}
+		}
+		// Finally, append a line containing the error message.
+		reportMsg += "Error message: " + report.Message + "\n\n"
+	}
+	return reportMsg
+}

--- a/ceno-reader/tests/bundleserver.go
+++ b/ceno-reader/tests/bundleserver.go
@@ -63,7 +63,7 @@ func reportBundleCreation(w http.ResponseWriter, r *http.Request) {
 		marshalled, _ := json.Marshal(BundleResponse{
 			Url:     requestedUrl,
 			Created: time.Now().Format(time.UnixDate),
-			Bundle:  "SOMEBLOBOFDATAREPRESENTINGABUNDLE",
+			Bundle:  `SOMEBUNDLEOFDATAREPRESENTINGAFEED`,
 		})
 		fmt.Println("Success!")
 		fmt.Println(string(marshalled))

--- a/ceno-reader/tools/zinapp-extract.py
+++ b/ceno-reader/tools/zinapp-extract.py
@@ -13,7 +13,7 @@ rows = table.tbody.find_all('tr')
 
 output = open('sources.list', 'w')
 for row in rows:
-    _, _, _, _, feed_url, feed_type = row.find_all('td')
+    _, _, _, _, feed_url, feed_type, _ = row.find_all('td')
     url = feed_url.a.text
     _type = feed_type.text
     if _type.lower() == 'html':

--- a/doc/osx-browsers.md
+++ b/doc/osx-browsers.md
@@ -1,0 +1,16 @@
+# Supported Browsers
+
+This document lists the locations of popular browsers for which CENO browser extensions exist.
+
+## Firefox
+
+    /Applications/Firefox.app/Contents/MacOS/firefox
+
+## Chromium
+
+    /Users/$USER/Applications/Chromium.app/Contents/MacOS/Chromium
+
+## Google Chrome
+
+    /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome
+


### PR DESCRIPTION
Addresses the user story "CC pages such as “node is not ready yet” should auto refresh".

Testing is fairly simple.

1. Run `./build.sh` in `ceno/ceno-client` to compile the ceno client and the feature test tool
2. Run the mock LCS with `./test/erroringlcs`
3. Run the CC with `./client`
4. In your browser, navigate to `http://localhost:3090/lookup?url=aHR0cHM6Ly9nb29nbGUuY2E=` to request `https://google.ca`
5. Carefully watch the page to observe it refreshing after **five** seconds.