### PR TITLE
JSON files for testing

### DIFF
--- a/ceno-client/json-files/aHR0cDovL25ld3MueWNvbWJpbmF0b3IuY29tL3Jzcw==.json
+++ b/ceno-client/json-files/aHR0cDovL25ld3MueWNvbWJpbmF0b3IuY29tL3Jzcw==.json
@@ -1,0 +1,1 @@
+{"items":[],"version":1}

--- a/ceno-client/json-files/feeds.json
+++ b/ceno-client/json-files/feeds.json
@@ -1,0 +1,1 @@
+{"feeds":[],"version":1}

--- a/ceno-client/json-files/feeds2.json
+++ b/ceno-client/json-files/feeds2.json
@@ -1,0 +1,1 @@
+{"feeds":[{"Id":1,"url":"http://news.ycombinator.com/rss","type":"RSS","charset":"","articles":30,"lastPublished":"Wed, 11 Nov 2015 09:41:22 +0000","latest":"On Being Smart (2009) [pdf]"}],"version":1}


### PR DESCRIPTION
Files are added here solely for the purpos of testing that the ceno client doesn't throw any absurd errors when either:

1. There is an error loading either `feeds.json` or an article list file
2. There is an error decoding any json files
3. Either feeds.json doesn't exist or the article the user wants to visit doesn't exist

You can test this all out by running the client and visiting `localhost:3090/portal` to observe a page listed with no feeds.  If you then substitute `json-files/feeds2.json` for `json-files/feeds.json` and reload the portal, you'll see Hacker News there and, upon clicking it, will see a page with no articles listed.
Finally, you can outright delete `json-files/feeds.json` and navigate back to `localhost:3090/portal` and observe a standard error page saying the file couldn't be loaded.