### PR TITLE
Autoinsert json

### DIFF
--- a/ceno-reader/src/reader.go
+++ b/ceno-reader/src/reader.go
@@ -147,7 +147,7 @@ func followFeeds(requests chan SaveFeedRequest) {
 			return
 		} else {
 			log("Saved")
-			writeFeedsErr := writeFeeds(feeds)
+			writeFeedsErr := writeFeeds([]Feed{feedInfo})
 			if writeFeedsErr != nil {
 				log("Error writing feeds file")
 				log(writeFeedsErr)
@@ -251,16 +251,16 @@ func insertHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, feed := range feeds {
-		items, itemserror := getitems(dbconnection, feed.url)
-		if itemserror != nil {
-			log("couldn't get items for " + feed.url)
-			log(itemserror)
+		items, itemsError := GetItems(DBConnection, feed.Url)
+		if itemsError != nil {
+			log("couldn't get items for " + feed.Url)
+			log(itemsError)
 		} else {
 			log(items)
-			log("items for " + feed.url)
-			writeItemserr := writeItems(feed.url, items)
-			if writeItemserr != nil {
-				log("could not write items for " + feed.url)
+			log("items for " + feed.Url)
+			writeItemsErr := writeItems(feed.Url, items)
+			if writeItemsErr != nil {
+				log("could not write items for " + feed.Url)
 			} else {
 				log("success!")
 			}

--- a/ceno-reader/src/reader.go
+++ b/ceno-reader/src/reader.go
@@ -47,7 +47,7 @@ func channelFeedHandler(feed *rss.Feed, newChannels []*rss.Channel) {
 }
 
 /**
- * Handle the receipt of a new item.
+ * Handle the receipt of new items.
  * @param {*rss.Feed} feed - A pointer to the object representing the feed received from
  * @param {*rss.Channel} channel - A pointer to the channel object the item was received from
  * @param {[]*rss.Item} newItems - An array of pointers to items received from the channel
@@ -78,6 +78,19 @@ func itemFeedHandler(feed *rss.Feed, channel *rss.Channel, newItems []*rss.Item)
 			}
 		} else {
 			log(T("insertion_fail_err"))
+		}
+	}
+	items, itemsError := GetItems(DBConnection, feed.Url)
+	if itemsError != nil {
+		log("couldn't get items for " + feed.Url)
+		log(itemsError)
+	} else {
+		writeItemsErr := writeItems(feed.Url, items)
+		if writeItemsErr != nil {
+			log("could not write items for " + feed.Url)
+			log(writeItemsErr)
+		} else {
+			log("success!")
 		}
 	}
 }
@@ -111,7 +124,7 @@ func pollFeed(URL string, charsetReader xmlx.CharsetFunc) {
 			log(errMsg)
 			SaveError(DBConnection, NewErrorReport(RssFeed, InvalidUrl|Malformed, errMsg))
 		}
-		<-time.After(time.Duration(feed.SecondsTillUpdate() * 1e9))
+		<-time.After(3 * time.Hour)
 	}
 }
 
@@ -134,6 +147,13 @@ func followFeeds(requests chan SaveFeedRequest) {
 			return
 		} else {
 			log("Saved")
+			writeFeedsErr := writeFeeds(feeds)
+			if writeFeedsErr != nil {
+				log("Error writing feeds file")
+				log(writeFeedsErr)
+			} else {
+				log("Saved new feeds.json file and inserted it into Freenet")
+			}
 			request.W.Write([]byte(T("req_handle_success_rdr")))
 		}
 		if feedInfo.Charset == "" {
@@ -231,18 +251,18 @@ func insertHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, feed := range feeds {
-		items, itemsError := GetItems(DBConnection, feed.Url)
-		if itemsError != nil {
-			log("Couldn't get items for " + feed.Url)
-			log(itemsError)
+		items, itemserror := getitems(dbconnection, feed.url)
+		if itemserror != nil {
+			log("couldn't get items for " + feed.url)
+			log(itemserror)
 		} else {
 			log(items)
-			log("Items for " + feed.Url)
-			writeItemsErr := writeItems(feed.Url, items)
-			if writeItemsErr != nil {
-				log("Could not write items for " + feed.Url)
+			log("items for " + feed.url)
+			writeItemserr := writeItems(feed.url, items)
+			if writeItemserr != nil {
+				log("could not write items for " + feed.url)
 			} else {
-				log("Success!")
+				log("success!")
 			}
 		}
 	}


### PR DESCRIPTION
Changes:
1. Reader polls RSS/Atom feed when a new feed is followed but then only every three hours
2. After a feed has been polled and all items are processed, Reader will automatically request each article.json file be re-inserted and will overwrite the json file on disk
3. The `feeds.json` file will only be inserted when a new feed is followed

To test (in `ceno/ceno-reader`):

``` bash
# Clean things up to prepare for test
rm feeds.db
rm -f json-files/*.json
./build.sh
./bundleinserter
./bundleserver
./reader
curl :3096/follow -H "Content-Type: application/json" -d '{"url": "https://news.ycombinator.com/rss"}'
ls json-files/
```

You will see output from each server indicating that the follow request was processed and that articles were received and inserted.

You'll also see after the last `ls` command that new json files in `json-files/` have been created, meaning the bundle inserter gave an okay saying the insertion worked and so the Reader wrote the files to disk for distribution with the CC.

This should obviously be tested with the real BS and BI.

Caveat: Waiting three hours to ensure the polling is less frequent. Read the commit diff and trust that I multiplied the right numbers together.
