### PR TITLE
Extending reader

### DIFF
--- a/ceno-reader/src/data.go
+++ b/ceno-reader/src/data.go
@@ -100,6 +100,7 @@ const MAX_BUNDLE_SIZE ByteSize = 100 * Megabytes
 type Feed struct {
 	Id            int
 	Url           string `json:"url"`
+	Logo          string `json:"logo"`
 	Type          string `json:"type"`
 	Charset       string `json:"charset"`
 	Articles      int    `json:"articles"`

--- a/ceno-reader/src/data.go
+++ b/ceno-reader/src/data.go
@@ -3,7 +3,6 @@ package main
 import (
 	"database/sql"
 	"github.com/jteeuwen/go-pkg-xmlx"
-	"net/http"
 	"path"
 	"time"
 )
@@ -131,14 +130,18 @@ type ErrorReport struct {
 	ErrorMessage  string
 }
 
-/**
- * Pair a Feed with a ResponseWriter to be sent accross a channel
- * So that a separate goroutine can try to handle DB operations and
- * write back to the client.
- */
+// Contains information about a request to have a feed followed.
 type SaveFeedRequest struct {
 	FeedInfo Feed
-	W        http.ResponseWriter
+	Response chan string
+}
+
+func (r SaveFeedRequest) Feed() Feed {
+	return r.FeedInfo
+}
+
+func (r SaveFeedRequest) Respond(msg string) {
+	r.Response <- msg
 }
 
 /**

--- a/ceno-reader/src/data.go
+++ b/ceno-reader/src/data.go
@@ -133,15 +133,10 @@ type ErrorReport struct {
 // Contains information about a request to have a feed followed.
 type SaveFeedRequest struct {
 	FeedInfo Feed
-	Response chan string
 }
 
 func (r SaveFeedRequest) Feed() Feed {
 	return r.FeedInfo
-}
-
-func (r SaveFeedRequest) Respond(msg string) {
-	r.Response <- msg
 }
 
 /**

--- a/ceno-reader/src/freenet_test.go
+++ b/ceno-reader/src/freenet_test.go
@@ -81,10 +81,10 @@ func TestGetBundle(t *testing.T) {
 			response, _ := json.Marshal(map[string]string{"error": lastErrMsg})
 			w.Write(response)
 		} else {
-			response, _ := json.Marshal(map[string]string{
-				"created": "now",
-				"url":     strUrl,
-				"bundle":  "Hello world!",
+			response, _ := json.Marshal(BundleContainer{
+				"now",
+				strUrl,
+				"Hello world!",
 			})
 			w.Write(response)
 		}

--- a/ceno-reader/src/persistence.go
+++ b/ceno-reader/src/persistence.go
@@ -18,6 +18,7 @@ import (
 const createFeedsTable = `create table if not exists feeds(
     id integer primary key,
     url varchar(255) unique,
+		logo varchar(255),
     type varchar(8),
     charset varchar(64),
     articles integer,
@@ -99,9 +100,9 @@ func SaveFeed(db *sql.DB, feed Feed) error {
 		return err1
 	}
 	_, err2 := tx.Exec(`
-        insert into feeds(url, type, charset, articles, lastPublished, latest)
-        values(?,?,?,?,?,?)`,
-		feed.Url, feed.Type, feed.Charset, feed.Articles, feed.LastPublished, feed.Latest)
+        insert into feeds(url, logo, type, charset, articles, lastPublished, latest)
+        values(?,?,?,?,?,?,?)`,
+		feed.Url, feed.Logo, feed.Type, feed.Charset, feed.Articles, feed.LastPublished, feed.Latest)
 	if err2 != nil {
 		return err2
 	}
@@ -119,18 +120,18 @@ func AllFeeds(db *sql.DB) ([]Feed, error) {
 	if err1 != nil {
 		return feeds, err1
 	}
-	rows, err2 := tx.Query(`select id, url, type, charset, articles, lastPublished, latest
+	rows, err2 := tx.Query(`select id, url, logo, type, charset, articles, lastPublished, latest
                             from feeds`)
 	if err2 != nil {
 		return feeds, err2
 	}
 	for rows.Next() {
-		var url, _type, charset, lastPublished, latest string
+		var url, logo, _type, charset, lastPublished, latest string
 		var id, articles int
-		rows.Scan(&id, &url, &_type, &charset, &articles, &lastPublished, &latest)
+		rows.Scan(&id, &url, &logo, &_type, &charset, &articles, &lastPublished, &latest)
 		fmt.Printf("Found feed %s with %d articles. Last published %s on %s.\n",
 			url, articles, latest, lastPublished)
-		feeds = append(feeds, Feed{id, url, _type, charset, articles, lastPublished, latest})
+		feeds = append(feeds, Feed{id, url, logo, _type, charset, articles, lastPublished, latest})
 	}
 	rows.Close()
 	return feeds, nil
@@ -147,7 +148,7 @@ func GetFeed(db *sql.DB, url string) (Feed, error) {
 	if err1 != nil {
 		return feed, err1
 	}
-	stmt, err2 := tx.Prepare(`select id, url, type, charset, articles, lastPublished, latest
+	stmt, err2 := tx.Prepare(`select id, url, logo, type, charset, articles, lastPublished, latest
                               from feeds where url=?`)
 	if err2 != nil {
 		return feed, err2
@@ -158,10 +159,10 @@ func GetFeed(db *sql.DB, url string) (Feed, error) {
 		return feed, err3
 	}
 	var id, articles int
-	var _type, charset, lastPublished, latest string
-	rows.Scan(&id, &url, &_type, &charset, &articles, &lastPublished, &latest)
+	var logo, _type, charset, lastPublished, latest string
+	rows.Scan(&id, &url, &logo, &_type, &charset, &articles, &lastPublished, &latest)
 	rows.Close()
-	return Feed{id, url, _type, charset, articles, lastPublished, latest}, nil
+	return Feed{id, url, logo, _type, charset, articles, lastPublished, latest}, nil
 }
 
 /**

--- a/ceno-reader/src/reader.go
+++ b/ceno-reader/src/reader.go
@@ -123,21 +123,18 @@ func pollFeed(URL string, charsetReader xmlx.CharsetFunc) {
  * @param {chan Feed} requests - A channel through which descriptions of feeds to be followed are received
  */
 func followFeeds(requests chan SaveFeedRequest) {
-	//T, _ := i18n.Tfunc(os.Getenv(LANG_ENVVAR), DEFAULT_LANG)
+	T, _ := i18n.Tfunc(os.Getenv(LANG_ENVVAR), DEFAULT_LANG)
 	for {
 		request := <-requests
 		feedInfo := request.Feed()
-		log("Got a request to handle a feed.")
-		log(feedInfo)
 		saveErr := SaveFeed(DBConnection, feedInfo)
 		if saveErr != nil {
-			log("Could not save")
-			log(saveErr)
-			//errMsg := T("db_store_error_rdr", map[string]interface{}{"Error": saveErr.Error()})
+			errMsg := T("db_store_error_rdr", map[string]interface{}{"Error": saveErr.Error()})
+			log(errMsg)
 			return
 		} else {
-			log("Saved")
-			////msg := T("req_handle_success_rdr")
+			msg := T("req_handle_success_rdr")
+			log(msg)
 		}
 		if feedInfo.Charset == "" {
 			go pollFeed(feedInfo.Url, nil)

--- a/ceno-reader/src/reader.go
+++ b/ceno-reader/src/reader.go
@@ -17,13 +17,8 @@ import (
 	"time"
 )
 
-// A message for the user to receive after requesting a new feed be followed.
-const FOLLOW_REQ_MSG = `Your request is being processed.
-If anything goes wrong, an error will be recorded.
-You can have a report about errors generated using this service's /errors route.
-Use the following curl command:
-    curl :3096/errors
-`
+// The ID of A message for the user to receive after requesting a new feed be followed.
+const FOLLOW_REQ_MSG = "follow_request_msg"
 
 /**
  * Log the current time and a message
@@ -190,7 +185,7 @@ func followHandler(requests chan SaveFeedRequest) func(http.ResponseWriter, *htt
 			return
 		}
 		requests <- SaveFeedRequest{feedInfo}
-		w.Write([]byte(FOLLOW_REQ_MSG))
+		w.Write([]byte(T(FOLLOW_REQ_MSG)))
 	}
 }
 

--- a/ceno-reader/src/reader_test.go
+++ b/ceno-reader/src/reader_test.go
@@ -8,18 +8,14 @@ import (
 	"testing"
 )
 
-// The URL of eQualit.ie's logo, which we will use as our test image in TestInsertImage
-const EQ_LOGO_URL = "https://equalit.ie/wp-content/uploads/2014/06/eq-logo03-e1401820293471.png"
+// The URL of a test logo, which we will use as our test image in TestInsertImage
+const LOGO_URL = "https://news.ycombinator.com/y18.gif"
 
 func TestInsertImage(t *testing.T) {
 	// Acts like the bundle inserter
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		bundle := struct {
-			Created string `json:"created"`
-			Url     string `json:"url"`
-			Bundle  string `json:"bundle"`
-		}{}
+		bundle := BundleContainer{}
 		defer r.Body.Close()
 		decoder := json.NewDecoder(r.Body)
 		decodeErr := decoder.Decode(&bundle)
@@ -47,8 +43,8 @@ func TestInsertImage(t *testing.T) {
 	defer testServer.Close()
 	// Defined in test_helpers.go
 	SetPort(testServer.URL, BundleInserter)
-	status := InsertImage(EQ_LOGO_URL)
+	status := InsertImage(LOGO_URL)
 	if status == Failure {
-		t.Error("Request to insert eQualit.ie's logo failed.")
+		t.Error("Request to insert logo failed.")
 	}
 }

--- a/ceno-reader/src/reader_test.go
+++ b/ceno-reader/src/reader_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// The URL of eQualit.ie's logo, which we will use as our test image in TestInsertImage
+const EQ_LOGO_URL = "https://equalit.ie/wp-content/uploads/2014/06/eq-logo03-e1401820293471.png"
+
+func TestInsertImage(t *testing.T) {
+	// Acts like the bundle inserter
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		bundle := struct {
+			Created string `json:"created"`
+			Url     string `json:"url"`
+			Bundle  string `json:"bundle"`
+		}{}
+		defer r.Body.Close()
+		decoder := json.NewDecoder(r.Body)
+		decodeErr := decoder.Decode(&bundle)
+		lastErrMsg := ""
+		if decodeErr != nil {
+			lastErrMsg = decodeErr.Error()
+			t.Error(lastErrMsg)
+		}
+		_, parseErr := url.Parse(bundle.Url)
+		if parseErr != nil {
+			lastErrMsg = parseErr.Error()
+			t.Error(lastErrMsg)
+		}
+		if len(bundle.Bundle) == 0 {
+			lastErrMsg = "No bundle data available."
+			t.Error(lastErrMsg)
+		}
+		if len(lastErrMsg) > 0 {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(lastErrMsg))
+		} else {
+			w.Write([]byte("okay"))
+		}
+	}))
+	defer testServer.Close()
+	// Defined in test_helpers.go
+	SetPort(testServer.URL, BundleInserter)
+	status := InsertImage(EQ_LOGO_URL)
+	if status == Failure {
+		t.Error("Request to insert eQualit.ie's logo failed.")
+	}
+}

--- a/ceno-reader/src/test_helpers.go
+++ b/ceno-reader/src/test_helpers.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+)
+
+// A sort of enum used to identify an agent so that a configuration setting
+// pertaining to a particular agent can be changed.
+type Agent int
+
+const (
+	BundleInserter = iota
+	BundleServer   = iota
+)
+
+// A container for parsed responses from the bundle server
+type BundleContainer struct {
+	Created string `json:"created"`
+	Url     string `json:"url"`
+	Bundle  string `json:"bundle"`
+}
+
+/**
+ * Parse the port number from a URL and set the appropriate configuration value.
+ * @param URL - A URL of the form http://<address>:<port>/<path>
+ * @param agent - The identifier of which agent to set the configured port value of
+ * @return the port number parsed as a string, e.g. "8080"
+ */
+func SetPort(URL string, agent Agent) (port string) {
+	parsed, _ := url.Parse(URL)
+	parts := strings.Split(parsed.Host, ":")
+	port = parts[1]
+	if agent == BundleInserter {
+		Configuration.BundleInserter = "http://127.0.0.1:" + port
+	} else {
+		Configuration.BundleServer = "http://127.0.0.1:" + port
+	}
+	return
+}

--- a/ceno-reader/translations/en-us.all.json
+++ b/ceno-reader/translations/en-us.all.json
@@ -86,5 +86,9 @@
   {
     "id": "db_get_err",
     "translation": "Database query failed. Error: {{.Error}}"
+  },
+  {
+    "id": "follow_request_msg",
+    "translation": "Your request is being processed. If anything goes wrong, an error will be recorded. You can have a report about errors generated using this service's /errors route. Use the following curl command:   curl :3096/errors "
   }
 ]

--- a/ceno-reader/translations/en-us.all.json
+++ b/ceno-reader/translations/en-us.all.json
@@ -88,6 +88,14 @@
     "translation": "Database query failed. Error: {{.Error}}"
   },
   {
+    "id": "request_fail_err",
+    "translation": "Request for {{.URL}} failed. Error: {{.Error}}"
+  },
+  {
+    "id": "image_insert_fail_err",
+    "translation": "Failed to insert the following logo into Freenet: {{.Logo}}"
+  },
+  {
     "id": "follow_request_msg",
     "translation": "Your request is being processed. If anything goes wrong, an error will be recorded. You can have a report about errors generated using this service's /errors route. Use the following curl command:   curl :3096/errors "
   }

--- a/doc/readerAPI.md
+++ b/doc/readerAPI.md
@@ -31,30 +31,31 @@ same JSON syntax.  Optional arguments are typed `opt type`- for example, `opt st
 
 Method | Route     | Arguments | Description
 -------|-----------|-----------|------------
-POST   | /follow   | {"url": string, "type": opt string} | Instruct the reader to subscribe to a new feed
+POST   | /follow   | {"url": string, "logo": string, "type": opt string} | Instruct the reader to subscribe to a new feed
 DELETE | /unfollow | {"url": string} | Instruct the reader to unsubscribe from a feed
 POST   | /insert   | N/A       | Have the reader generate new JSON files describing feeds and insert and save them
 GET    | /errors   | N/A       | Have the reader write a human-friendly report about errors polling feeds
 
 ### Follow
 
-Argument | Example                          | Description
----------|----------------------------------|-------------
-url      | https://news.ycombinator.com/rss | The URL of an RSS or Atom feed to subscribe to
-type     | RSS, Atom                        | RSS if the feed is an RSS feed or Atom
+Argument | Example                              | Description
+---------|--------------------------------------|-------------
+url      | https://news.ycombinator.com/rss     | The URL of an RSS or Atom feed to subscribe to
+logo     | https://news.ycombinator.com/y18.gif | The URL of an image to use as the logo for the RSS feed in the CENO Portal
+type     | RSS, Atom                            | RSS if the feed is an RSS feed or Atom
 
 **Examples**
 
 curl:
 
 ```bash
-curl -XPOST :3096/follow -H "Content-Type: application/json" -d '{"url": "https://news.ycombinator.com/rss", "type": "rss"}'
+curl -XPOST :3096/follow -H "Content-Type: application/json" -d '{"url": "https://news.ycombinator.com/rss", "logo": "https://news.ycombinator.com/y18.gif", "type": "RSS"}'
 ```
 
 httpie:
 
 ```bash
-http POST :3096/follow url=https://news.ycombinator.com/rss type=RSS
+http POST :3096/follow url=https://news.ycombinator.com/rss logo=https://news.ycombinator.com/y18.gif type=RSS
 ```
 
 ### Unfollow


### PR DESCRIPTION
This branch does a few things.  There's some tidying up done, some new translatable strings provided, a generic response to /follow requests is added, and of course

    Logo images can now be associated with feeds!

I also wrote some more unit tests, and they get run automatically when you run `./build.sh` in the `ceno-reader/` directory.