### PR TITLE
Partner content

### DIFF
--- a/ceno-reader/src/config.go
+++ b/ceno-reader/src/config.go
@@ -18,8 +18,8 @@ type Config struct {
 
 // Default confifuration values that can be provided as options to the user.
 var DefaultConfiguration Config = Config{
-	PortNumber: ":3096",
-	BundleServer: "http://127.0.0.1:3094",
+	PortNumber:     ":3096",
+	BundleServer:   "http://127.0.0.1:3094",
 	BundleInserter: "http://127.0.0.1:3095",
 }
 

--- a/ceno-reader/src/persistence.go
+++ b/ceno-reader/src/persistence.go
@@ -19,7 +19,7 @@ import (
 // Create the table that contains information about RSS/Atom feeds the reader follows
 const createFeedsTable = `create table if not exists feeds(
     id integer primary key,
-    url varchar(255) unique,
+    url varchar(255) unique on conflict ignore,
     type varchar(8),
     charset varchar(64),
     articles integer,

--- a/ceno-reader/src/persistence.go
+++ b/ceno-reader/src/persistence.go
@@ -125,11 +125,7 @@ func SaveFeed(db *sql.DB, feed Feed) error {
  */
 func AllFeeds(db *sql.DB) ([]Feed, error) {
 	var feeds []Feed
-	tx, err1 := db.Begin()
-	if err1 != nil {
-		return feeds, err1
-	}
-	rows, err2 := tx.Query(`select id, url, type, charset, articles, lastPublished, latest
+	rows, err2 := db.Query(`select id, url, type, charset, articles, lastPublished, latest
                             from feeds`)
 	if err2 != nil {
 		return feeds, err2
@@ -154,11 +150,7 @@ func AllFeeds(db *sql.DB) ([]Feed, error) {
  */
 func GetFeed(db *sql.DB, url string) (Feed, error) {
 	var feed Feed
-	tx, err1 := db.Begin()
-	if err1 != nil {
-		return feed, err1
-	}
-	rows, err2 := tx.Query(`select id, url, type, charset, articles, lastPublished, latest
+	rows, err2 := db.Query(`select id, url, type, charset, articles, lastPublished, latest
                               from feeds where url=?`)
 	if err2 != nil {
 		return feed, err2
@@ -236,11 +228,7 @@ func SaveItem(db *sql.DB, feedUrl string, item *rss.Item) error {
  */
 func GetItems(db *sql.DB, feedUrl string) ([]Item, error) {
 	var items []Item
-	tx, err1 := db.Begin()
-	if err1 != nil {
-		return items, err1
-	}
-	rows, err2 := tx.Query(`select id, title, url, authors, published from items where feed_url=?`,
+	rows, err2 := db.Query(`select id, title, url, authors, published from items where feed_url=?`,
 		feedUrl)
 	if err2 != nil {
 		return items, err2
@@ -306,14 +294,10 @@ func SaveError(db *sql.DB, report ErrorReport) error {
  */
 func GetErrors(db *sql.DB) ([]ErrorReport, error) {
 	reports := make([]ErrorReport, 0)
-	tx, err := db.Begin()
-	if err != nil {
-		return reports, err
-	}
 	// Get the relevant rows from the database.
 	// Note that error types and resource types are specified in the database as integers.
 	// That means we do the usual binary operations to find them.
-	rows, queryError := tx.Query(`select id, resource_types, error_types, message from errors`)
+	rows, queryError := db.Query(`select id, resource_types, error_types, message from errors`)
 	if queryError != nil {
 		return reports, queryError
 	}
@@ -326,10 +310,9 @@ func GetErrors(db *sql.DB) ([]ErrorReport, error) {
 		})
 	}
 	rows.Close()
-	_, execError := tx.Exec(`delete from errors`)
+	_, execError := db.Exec(`delete from errors`)
 	if execError != nil {
 		return reports, execError
 	}
-	tx.Commit()
 	return reports, nil
 }

--- a/ceno-reader/src/persistence.go
+++ b/ceno-reader/src/persistence.go
@@ -173,7 +173,7 @@ func DeleteFeed(db *sql.DB, url string) error {
 	if err1 != nil {
 		return err1
 	}
-	_, err2 := tx.Exec("delete from feeds where url=?")
+	_, err2 := tx.Exec("delete from feeds where url=?", url)
 	if err2 != nil {
 		return err2
 	}

--- a/ceno-reader/src/persistence.go
+++ b/ceno-reader/src/persistence.go
@@ -8,8 +8,8 @@ package main
 
 import (
 	"database/sql"
-	rss "github.com/jteeuwen/go-pkg-rss"
 	"fmt"
+	rss "github.com/jteeuwen/go-pkg-rss"
 	_ "github.com/mattn/go-sqlite3"
 	"time"
 )
@@ -158,15 +158,10 @@ func GetFeed(db *sql.DB, url string) (Feed, error) {
 	if err1 != nil {
 		return feed, err1
 	}
-	stmt, err2 := tx.Prepare(`select id, url, type, charset, articles, lastPublished, latest
+	rows, err2 := tx.Query(`select id, url, type, charset, articles, lastPublished, latest
                               from feeds where url=?`)
 	if err2 != nil {
 		return feed, err2
-	}
-	defer stmt.Close()
-	rows, err3 := stmt.Query(url)
-	if err3 != nil {
-		return feed, err3
 	}
 	var id, articles int
 	var _type, charset, lastPublished, latest string
@@ -186,14 +181,9 @@ func DeleteFeed(db *sql.DB, url string) error {
 	if err1 != nil {
 		return err1
 	}
-	stmt, err2 := tx.Prepare("delete from feeds where url=?")
+	_, err2 := tx.Exec("delete from feeds where url=?")
 	if err2 != nil {
 		return err2
-	}
-	defer stmt.Close()
-	_, err3 := stmt.Exec(url)
-	if err3 != nil {
-		return err3
 	}
 	tx.Commit()
 	return nil
@@ -250,15 +240,10 @@ func GetItems(db *sql.DB, feedUrl string) ([]Item, error) {
 	if err1 != nil {
 		return items, err1
 	}
-	stmt, err2 := tx.Prepare(`select id, title, url, authors, published
-                              from items where feed_url=?`)
+	rows, err2 := tx.Query(`select id, title, url, authors, published from items where feed_url=?`,
+		feedUrl)
 	if err2 != nil {
 		return items, err2
-	}
-	defer stmt.Close()
-	rows, err3 := stmt.Query(feedUrl)
-	if err3 != nil {
-		return items, err3
 	}
 	for rows.Next() {
 		var id int
@@ -281,14 +266,9 @@ func DeleteItem(db *sql.DB, id int) error {
 	if err1 != nil {
 		return err1
 	}
-	stmt, err2 := tx.Prepare("delete from items where id=?")
+	_, err2 := tx.Exec("delete from items where id=?")
 	if err2 != nil {
 		return err2
-	}
-	defer stmt.Close()
-	_, err3 := stmt.Exec(id)
-	if err3 != nil {
-		return err3
 	}
 	tx.Commit()
 	return nil


### PR DESCRIPTION
As best as possible fixes the problem of having an error saying that transactions cannot be executed inside other transactions.  It also fixes the problem of being unable to unfollow feeds.  Finally, this branch also prevents an error from being raised when the UNIQUE constraint on the `url` field of the feeds table is broken by a follow request.  As a result, users will see a message that the feed they asked to follow has been followed, even though no change has occurred, but they won't be prevented from making further requests.

As long as requests are spaced far enough apart that the DB's connection pool isn't used up, there shouldn't be problems with the first error.