### PR TITLE
Issue172

### DIFF
--- a/ceno-client/.jshintrc
+++ b/ceno-client/.jshintrc
@@ -18,6 +18,7 @@
   "module": true,
   "globals": {
     "LANGUAGES": false,
+    "CURRENT_LOCALE": false,
     "languages": false,
     "navigation": false
   }

--- a/ceno-client/portal/html/resources.html
+++ b/ceno-client/portal/html/resources.html
@@ -4,5 +4,6 @@
 <link rel="stylesheet" type="text/css" href="/cenoresources/stylesheets/main.css" />
 <script type="text/javascript" id="jsonPlaceholder">
   var LANGUAGES = JSON.parse('{{.LanguageStringsAsJSON}}');
+  var CURRENT_LOCALE = '{{.CurrentLocale}}';
 </script>
 {{end}}

--- a/ceno-client/portal/js/about.js
+++ b/ceno-client/portal/js/about.js
@@ -1,5 +1,5 @@
 (function () {
 
-languages.setAboutText('en');
+languages.setAboutText(CURRENT_LOCALE);
 
 })();

--- a/ceno-client/portal/js/articles.js
+++ b/ceno-client/portal/js/articles.js
@@ -1,5 +1,5 @@
 (function () {
 
-languages.setChannelText('en');
+languages.setChannelText(CURRENT_LOCALE);
 
 })();

--- a/ceno-client/portal/js/channels.js
+++ b/ceno-client/portal/js/channels.js
@@ -1,5 +1,5 @@
 (function () {
 
-languages.setChannelText('en');
+languages.setChannelText(CURRENT_LOCALE);
 
 })();

--- a/ceno-client/portal/js/index.js
+++ b/ceno-client/portal/js/index.js
@@ -38,6 +38,6 @@ if (urlInputForm) {
   }
 }
 
-languages.setIndexText('en');
+languages.setIndexText(CURRENT_LOCALE);
 
 })();

--- a/ceno-client/portal/js/languages.js
+++ b/ceno-client/portal/js/languages.js
@@ -154,6 +154,7 @@ function setPortalText(locale) {
   setIndexText(locale);
   setChannelText(locale);
   setArticleText(locale);
+  setAboutText(locale);
 }
 
 // When a language is selected, get its locale and reset the text on the page.

--- a/ceno-client/src/client.go
+++ b/ceno-client/src/client.go
@@ -332,6 +332,7 @@ func main() {
 	http.Handle("/cenoresources/",
 		http.StripPrefix("/cenoresources/", http.FileServer(http.Dir("./static"))))
 	http.HandleFunc("/lookup", directHandler)
+	http.HandleFunc("/locale", PortalLocaleHandler)
 	http.HandleFunc("/about", PortalAboutHandler)
 	http.HandleFunc("/portal", PortalIndexHandler)
 	http.HandleFunc("/channels", PortalChannelsHandler)

--- a/ceno-client/src/portal.go
+++ b/ceno-client/src/portal.go
@@ -233,6 +233,7 @@ func PortalIndexHandler(w http.ResponseWriter, r *http.Request) {
 		// For the javascript code that applies strings
 		module["LanguageStringsAsJSON"] = stringifyLanguages(langStringsJson)
 	}
+	module["CurrentLocale"] = CurrentLocale
 	t.Execute(w, module)
 }
 
@@ -256,6 +257,7 @@ func PortalChannelsHandler(w http.ResponseWriter, r *http.Request) {
 			// For the javascript code that applies strings
 			module["LanguageStringsAsJSON"] = stringifyLanguages(langStringsJson)
 		}
+		module["CurrentLocale"] = CurrentLocale
 		t.Execute(w, module)
 	}
 }
@@ -286,6 +288,7 @@ func PortalArticlesHandler(w http.ResponseWriter, r *http.Request) {
 			// For the javascript code that applies strings
 			module["LanguageStringsAsJSON"] = stringifyLanguages(langStringsJson)
 		}
+		module["CurrentLocale"] = CurrentLocale
 		t.Execute(w, module)
 	}
 }
@@ -308,6 +311,7 @@ func PortalAboutHandler(w http.ResponseWriter, r *http.Request) {
 		// For the Javascript code that applies strings
 		module["LanguageStringsAsJSON"] = stringifyLanguages(langJson)
 	}
+	module["CurrentLocale"] = CurrentLocale
 	t.Execute(w, module)
 }
 

--- a/ceno-client/src/portal.go
+++ b/ceno-client/src/portal.go
@@ -13,6 +13,9 @@ import (
 	"strings"
 )
 
+// A global variable set by the handler for the POST /locale route
+var CurrentLocale string = "en"
+
 type PortalPath struct {
 	PageName string
 	Href     string
@@ -306,4 +309,37 @@ func PortalAboutHandler(w http.ResponseWriter, r *http.Request) {
 		module["LanguageStringsAsJSON"] = stringifyLanguages(langJson)
 	}
 	t.Execute(w, module)
+}
+
+type SetLocaleRequest struct {
+	Locale string `json:"locale"`
+}
+
+func PortalLocaleHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	// We'll write error messages but only really use them for debugging purposes on the client side.
+	if r.Method != "POST" {
+		w.Write([]byte(`{"success": false, "error": "Only post requests accepted to the /locale route."}`))
+		return
+	}
+	requestData := SetLocaleRequest{}
+	decoder := json.NewDecoder(r.Body)
+	decodeErr := decoder.Decode(&requestData)
+	if decodeErr != nil {
+		w.Write([]byte(`{"success": false, "error": "` + decodeErr.Error() + `"}`))
+		return
+	}
+	localeIsSupported := false
+	for _, supportedLanguage := range Configuration.PortalLanguages {
+		if requestData.Locale == supportedLanguage.Locale {
+			localeIsSupported = true
+			break
+		}
+	}
+	if !localeIsSupported {
+		w.Write([]byte(`{"success": false, "error": "Unsupported locale ` + requestData.Locale + `."}`))
+	} else {
+		CurrentLocale = requestData.Locale
+		w.Write([]byte(`{"success": true}`))
+	}
 }


### PR DESCRIPTION
Implements locale persistence across a CENO session.  That is, between starting and closing CENO, the locale set in the CENO Portal will be persisted and automatically set on each portal page viewed after changing the locale.

To test:

1. Checkout branch
2. Run `./build.sh` in `ceno-client/`
3. Navigate browser to `http://localhost:3090/portal`
4. Change locale
5. Navigate to a new page, e.g. `http://localhost:3090/channels`
6. Observe the locale has persisted

Notes:

1. If any errors are occurring, they will be logged in your browser's Javacsript console. If something isn't working, please check what's output there and include the message(s) in any bug reports.
2. Please ensure **you are not running noscript/have JS disabled** while testing. Like the rest of the portal, this feature requires Javascript be allowed to run on the portal pages.