### PR TITLE
ceno-client: add jshint dependency

### DIFF
--- a/ceno-client/package.json
+++ b/ceno-client/package.json
@@ -19,6 +19,7 @@
     "gulp-concat": "latest",
     "gulp-jshint": "latest",
     "gulp-jsoncombine": "latest",
+    "jshint": "latest",
     "jshint-stylish": "latest",
     "urlsafe-base64": "latest"
   }


### PR DESCRIPTION
I was unable to build until I installed this:

    npm WARN gulp-jshint@2.0.0 requires a peer of jshint@2.x but none was installed.
    *  Building resources.
    module.js:329
       throw err;
       ^
    
    Error: Cannot find module 'jshint/src/cli'
       at Function.Module._resolveFilename (module.js:327:15)
       at Function.Module._load (module.js:278:25)
       at Module.require (module.js:355:17)
       at require (internal/module.js:13:17)
       at Object.<anonymous> (/home/steve/Documents/Coding/ceno/ceno-client/node_modules/gulp-jshint/src/extract.js:1:17)
       at Module._compile (module.js:399:26)
       at Object.Module._extensions..js (module.js:406:10)
       at Module.load (module.js:345:32)
       at Function.Module._load (module.js:302:12)
       at Module.require (module.js:355:17)
       at require (internal/module.js:13:17)