### PR TITLE
Refactor #151: Keep established signaling channels in bridge.db

### DIFF
--- a/ceno-freenet/build.xml
+++ b/ceno-freenet/build.xml
@@ -19,8 +19,7 @@
 	<property name="apache-commonsvalidator.location" location="lib/commons-validator-1.4.1.jar"/>
 	<property name="apache-commonscompress.location" location="lib/commons-compress-1.9.jar"/>
 	<property name="bouncy-castle.location" location="../fred/lib/bcprov-jdk15on-152.jar"/>
-    <property name="sqlite.location" location="/usr/share/java/sqlite.jar"/>
-    <property name="sqlite-jdbc.location" location="/usr/share/java/sqlite-jdbc/sqlite-jdbc.jar"/>
+	<property name="sqlite-jdbc.location" location="lib/sqlite-jdbc-3.8.11.2.jar"/>
 
 	<available file="src/plugins/CENO/Version.java" property="version.present"/>
 	<available file="${junit.location}" property="junit.present"/>
@@ -43,7 +42,7 @@
 		</copy>
 	</target>
 
-    
+
 	<!-- ================================================== -->
 	<target name="setver">
 		<!-- Update the Version file -->
@@ -74,8 +73,7 @@
 				<pathelement location="${apache-commonsvalidator.location}" />
 				<pathelement location="${apache-commonscompress.location}" />
 				<pathelement location="${bouncy-castle.location}" />
-                <pathelement location="${sqlite.location}" />
-                <pathelement location="${sqlite-jdbc.location}" />
+				<pathelement location="${sqlite-jdbc.location}" />
 
 			</classpath>
 			<include name="**/*.java"/>
@@ -169,6 +167,7 @@
 			<zipfileset src="${json-smart.location}" />
 			<zipfileset src="${apache-commonsvalidator.location}" excludes="META-INF/" />
 			<zipfileset src="${apache-commonscompress.location}" excludes="META-INF/" />
+			<zipfileset src="${sqlite-jdbc.location}" />
 		</jar>
 
 		<jar jarfile="${dist}/CENOBackbone.jar" duplicate="fail">

--- a/ceno-freenet/src/plugins/CENO/Bridge/BridgeDatabase.java
+++ b/ceno-freenet/src/plugins/CENO/Bridge/BridgeDatabase.java
@@ -15,127 +15,130 @@ import freenet.support.Logger;
 public class BridgeDatabase
 {
 
-    //String databasePath;
-    Connection _conn = null;
-    /**
-     * Constructor 
-     * 
-     * It opens the sqlite bridge database, creates it if it doesn't exists.
-     * then create the table structure if doesn't exists
-     *
-     * @param databasePath is the path ot the file which stores sqlite
-     *        database
-     */
-    public BridgeDatabase(String databasePath) throws CENOException
-    //: databasePath(databasePath)
-    {
-        //Sanity check
-        if (_conn != null) {
-            Logger.error(this, "Already connected to the database.");
-        } else {
-            try {
-                Class.forName("org.sqlite.JDBC");
-                String jdbcString = "jdbc:sqlite:"+databasePath;
-                _conn = DriverManager.getConnection(jdbcString);
-                CreateDatabaseStructure();
-            } catch ( Exception e ) {
-                throw new CENOException(CENOErrCode.LCS_DATABASE_CONNECT_FAILED, "Could not connect to the bridge database");
-            }
-        }
-    }
+	//String databasePath;
+	Connection _conn = null;
+	/**
+	 * Constructor 
+	 * 
+	 * It opens the sqlite bridge database, creates it if it doesn't exists.
+	 * then create the table structure if doesn't exists
+	 *
+	 * @param databasePath is the path ot the file which stores sqlite
+	 *        database
+	 */
+	public BridgeDatabase(String databasePath) throws CENOException
+	//: databasePath(databasePath)
+	{
+		//Sanity check
+		if (_conn != null) {
+			Logger.error(this, "Already connected to the database.");
+		} else {
+			try {
+				Class.forName("org.sqlite.JDBC");
+				String jdbcString = "jdbc:sqlite:"+databasePath;
+				_conn = DriverManager.getConnection(jdbcString);
+				CreateDatabaseStructure();
+			} catch ( Exception e ) {
+				throw new CENOException(CENOErrCode.LCS_DATABASE_CONNECT_FAILED, "Could not connect to the bridge database");
+			}
+		}
+	}
 
-    /**
-     * Called by constructors Creates all the necessary tables in case 
-     * they do not exsit.
-     *
-     */
-    public void CreateDatabaseStructure() throws CENOException {
-        Statement sqlCommand = null;
-        //Sanity check
-        if (_conn == null) {
-            Logger.error(this, "Not connected to the database yet.");
-            throw new CENOException(CENOErrCode.RR_DATABASE_OPERATION_FAILED, "Failed to create channel table");
-        }
-        //Creating the channel table
-        try {
-            sqlCommand = _conn.createStatement();
-            String sqlString = "CREATE TABLE IF NOT EXISTS channels " +
-                "(id INTEGER PRIMARY KEY AUTOINCREMENT," +
-                "privateSSK TEXT NOT NULL," +
-                "lastKnownVersion INT," +
-                "lastSynced TEXT);";
-            sqlCommand.executeUpdate(sqlString);
-            sqlCommand.close();
-        } catch ( Exception e ) {
-            throw new CENOException(CENOErrCode.RR_DATABASE_OPERATION_FAILED, "Failed to create channel table");
-            
-        }
-    
-    }
+	/**
+	 * Called by constructors Creates all the necessary tables in case 
+	 * they do not exsit.
+	 *
+	 */
+	public void CreateDatabaseStructure() throws CENOException {
+		Statement sqlCommand = null;
+		//Sanity check
+		if (_conn == null) {
+			Logger.error(this, "Not connected to the database yet.");
+			throw new CENOException(CENOErrCode.RR_DATABASE_OPERATION_FAILED, "Failed to create channel table");
+		}
+		//Creating the channel table
+		try {
+			sqlCommand = _conn.createStatement();
+			String sqlString = "CREATE TABLE IF NOT EXISTS channels " +
+					"(privateSSK TEXT PRIMARY KEY," +
+					"lastKnownVersion INT DEFAULT 0," +
+					"lastSynced INT DEFAULT CURRENT_TIMESTAMP);";
+			sqlCommand.executeUpdate(sqlString);
+			sqlCommand.close();
+		} catch ( Exception e ) {
+			throw new CENOException(CENOErrCode.RR_DATABASE_OPERATION_FAILED, "Failed to create channel table");
 
-    /**
-     *   reads the list of the registered channels from the channel table 
-     *
-     *   @return list of channels
-     */
-    public List<Channel> retrieveChannels() throws CENOException
-    {
-        Statement sqlCommand;
-        List<Channel> storedChannels = new ArrayList<Channel>();
-        
-        try {
-            sqlCommand = _conn.createStatement();
-            String sqlString = "SELECT * FROM channels; ";
+		}
 
-            ResultSet result = sqlCommand.executeQuery(sqlString);
+	}
 
-            while ( result.next() ) {
-                try {
-                    storedChannels.add(new Channel(result.getString("privateSSK"),
-                                               result.getLong("lastKnownVersion")));
-                } catch ( Exception e ) {
-                    Logger.error(this, "failed to add a channel for a stored SSK ");
-                }
-            }
-            result.close();
-            sqlCommand.close();
+	/**
+	 *   reads the list of the registered channels from the channel table 
+	 *
+	 *   @return list of channels
+	 */
+	public List<Channel> retrieveChannels() throws CENOException
+	{
+		Statement sqlCommand;
+		List<Channel> storedChannels = new ArrayList<Channel>();
 
-        } catch ( Exception e ) {
-            Logger.error(this, "failed to access the stored channel table");
-            throw new CENOException(CENOErrCode.RR_DATABASE_OPERATION_FAILED, "Failed to read the stored channel");
-            
-        }
+		try {
+			sqlCommand = _conn.createStatement();
+			String sqlString = "SELECT * FROM channels; ";
 
-        return storedChannels;
-        
-    }
+			ResultSet result = sqlCommand.executeQuery(sqlString);
 
-    /**
-     *   stores the given channel in the database for later retrieval
-     *
-     *   @param new channel ssk
-     *   @param provided edition
-     */
-    public void storeChannel(String insertSSK, Long providedEdition) throws CENOException
-    {
-        Statement sqlCommand;
-        try {
-            sqlCommand = _conn.createStatement();
-            
-            String sqlString = "INSERT INTO  channels (privateSSK,lastKnownVersion) " +
-                "VALUES ('" + insertSSK+ "', " + String.valueOf(providedEdition) + ");"; 
+			while ( result.next() ) {
+				try {
+					storedChannels.add(new Channel(result.getString("privateSSK"),
+							result.getLong("lastKnownVersion"), result.getLong("lastSynced")));
+				} catch ( Exception e ) {
+					Logger.error(this, "failed to add a channel for a stored SSK ");
+				}
+			}
+			result.close();
+			sqlCommand.close();
 
-            sqlCommand.executeUpdate(sqlString);
-            sqlCommand.close();
-            //_conn.commit(); auto commit is enabled by default
+		} catch ( Exception e ) {
+			Logger.error(this, "failed to access the stored channel table");
+			throw new CENOException(CENOErrCode.RR_DATABASE_OPERATION_FAILED, "Failed to read the stored channel");
 
-        } catch ( Exception e ) {
-            Logger.error(this,"Failed to store channel");
-            //throw new CENOException(CENOErrCode.LCS_DATABASE_OPERATION_FAILED, "Failed to store channel");
-            
-        }
+		}
 
-    }
+		return storedChannels;
+
+	}
+
+	/**
+	 *   stores the given channel in the database for later retrieval
+	 *
+	 *   @param new channel ssk
+	 *   @param provided edition
+	 */
+	public void storeChannel(String insertSSK, Long providedEdition, Long lastSynced) throws CENOException
+	{
+		Statement sqlCommand;
+		try {
+			sqlCommand = _conn.createStatement();
+
+			String sqlString = "INSERT OR REPLACE INTO  channels (privateSSK,lastKnownVersion,lastSynced) " +
+					"VALUES ('" + insertSSK+ "', " + providedEdition + ", " + lastSynced + ");"; 
+
+			sqlCommand.executeUpdate(sqlString);
+			sqlCommand.close();
+			//_conn.commit(); auto commit is enabled by default
+
+		} catch ( Exception e ) {
+			Logger.error(this,"Failed to store channel");
+			//throw new CENOException(CENOErrCode.LCS_DATABASE_OPERATION_FAILED, "Failed to store channel");
+
+		}
+
+	}
+
+	public void storeChannel(Channel channel) throws CENOException {
+		storeChannel(channel.getInsertSSK(), channel.getLastKnownEdition(), channel.getLastSynced());
+	}
 
 
 }

--- a/ceno-freenet/src/plugins/CENO/Bridge/Signaling/Channel.java
+++ b/ceno-freenet/src/plugins/CENO/Bridge/Signaling/Channel.java
@@ -21,16 +21,17 @@ import freenet.support.io.ResumeFailedException;
 public class Channel {
 	private FreenetURI insertSSK, requestSSK;
 	private Long lastKnownEdition = 0L;
+	private Long lastSynced = 0L;
 
 	public Channel() throws MalformedURLException {
-		this(null, null);
+		this(null, null, null);
 	}
 
 	public Channel(String insertSSK) throws MalformedURLException {
-		this(insertSSK, null);
+		this(insertSSK, null, null);
 	}
 
-	public Channel(String insertSSK, Long providedEdition) throws MalformedURLException {
+	public Channel(String insertSSK, Long providedEdition, Long lastSynced) throws MalformedURLException {
 		if (insertSSK == null) {
 			FreenetURI[] channelKeyPair = CENOBridge.nodeInterface.generateKeyPair();
 			this.insertSSK = channelKeyPair[0];
@@ -51,6 +52,20 @@ public class Channel {
 		if (insertURI.isUSK()) {
 			this.lastKnownEdition = insertURI.getEdition();
 		}
+
+		this.lastSynced = lastSynced != null ? lastSynced : 0;
+	}
+
+	public String getInsertSSK() {
+		return insertSSK.toASCIIString();
+	}
+
+	public Long getLastKnownEdition() {
+		return lastKnownEdition;
+	}
+
+	public Long getLastSynced() {
+		return lastSynced;
 	}
 
 	public void publishSyn() {
@@ -66,6 +81,7 @@ public class Channel {
 		} catch (PersistenceDisabledException e) {
 			Logger.error(this, "Excpetion while inserting Syn response to an insertion key provided by a client: " + e.getMessage());
 		}
+		this.lastSynced = System.currentTimeMillis();
 	}
 
 	public void subscribeToChannelUpdates() throws MalformedURLException {

--- a/ceno-freenet/src/plugins/CENO/Bridge/Signaling/ChannelManager.java
+++ b/ceno-freenet/src/plugins/CENO/Bridge/Signaling/ChannelManager.java
@@ -59,6 +59,10 @@ public class ChannelManager {
 		return false;
 	}
 
+	public List<Channel> getAllChannels() {
+		return channelList;
+	}
+
 	private void subscribeToChannel(Channel channel) throws MalformedURLException {
 		channel.publishSyn();
 		channel.subscribeToChannelUpdates();


### PR DESCRIPTION
Update bridge.db SSK channels schema; Update build.xml to use the sqlitedb.jar included in the lib directory; Read bridge.db path from bridge.properties configuration file; Store channels in bridge.db before unloading CENOBridge.jar plugin; Add lastSynced timestamp in channels
