### PR TITLE
Install gulp locally in client build script

### DIFF
--- a/ceno-client/build.sh
+++ b/ceno-client/build.sh
@@ -33,15 +33,10 @@ cd ..
 
 echo ""
 echo "Preparing CENO Portal."
-which gulp > /dev/null
-if [ $? -ne 0 ]; then
-    echo "*  Installing the gulp build tool."
-    npm install -g gulp
-fi
 echo "*  Installing any missing dependencies."
 npm install
 echo "*  Building resources."
-gulp build
+node_modules/gulp/bin/gulp.js build
 echo ""
 
 if [ $# -gt 0 ]; then

--- a/ceno-client/portal/README.md
+++ b/ceno-client/portal/README.md
@@ -51,6 +51,8 @@ Once Node and NPM are installed, gulp can be installed by running
 npm install -g gulp
 ```
 
+This is only needed if you intend to run gulp tasks manually.
+
 ## Building
 
 All of the content in the portal page is encapsulated in this directory, however in order


### PR DESCRIPTION
The invocation of ``npm install -g gulp`` in the script may fail if the user doesn't have write access to system directories (usually ``root`` permissions).  Also, the later building of resources fails and the build script doesn't detect this:

```
[...]
Preparing CENO Portal.
*  Installing the gulp build tool.
npm ERR! tar.unpack untar error /home/ivan/.npm/gulp/3.9.1/package.tgz
npm ERR! Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules'
[...]
*  Building resources.
./build.sh: 44: ./build.sh: gulp: not found

[SUCCESS] - Compiled CENO Client.
```

This change makes the installation of gulp local and then it invokes the local version in the build script.

Since the portal readme mentions that gulp tasks may be run independently, a note is added to point out that installing gulp globally is only needed if the user intends to run these tasks manually.