### PR TITLE
Better hints for installation in home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ If you want to build CENOBox manually, read these [instructions](BUILD.md).
 ### CENOBox in Linux and Mac OS X
 
 Change directory to the path you would like to install CENOBox at (we recommend
-your `/home` directory)
-and execute the following command:
+your home directory, as shown in the examples below),
+then download and execute the latest version of the installation script:
 
 ```bash
+cd ~
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/equalitie/ceno/master/ceno-box/installCENO.sh)"
 ```
 


### PR DESCRIPTION
The installation command also uses the home directory as in the invocation example just following it.  Also the verbatim ``/home`` directory in case someone tries to change to that exact directory, which would make the installation fail with insufficient permissions.