### PR TITLE
Point the user to update Freenet if not enough connections are achieved

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,11 @@ The first time you launch CENO, there are several things you need to know:
    means you need to wait a bit before you get results from CENO. As it learns,
    its gets faster. The CENO 'Status Indicator' will display CONNECTED when
    Freenet has discovered enough peers. This will happen every time you start
-   the software.
+   the software. If the status indicator stays for very long in UNSTABLE or NOT
+   CONNECTED, please click on it to get to CENO's Freenet portal page; if you
+   see a note about your Freenet software being out of date, please click the
+   update button and wait for some minutes; when the update is complete the
+   status indicator will display CONNECTED.
 3. Both CENO and Freenet use a local proxy client to connect with your browser.
    CENO is accessible via (<http://localhost:3090/portal>) and Freenet via
    (<http://localhost:8888>).


### PR DESCRIPTION
Otherwise a new user may have a hard time knowing why the node takes so much to connect (I was bitten by this).

I also tried to put a title attribute like "Open your Freenet portal page" in the status link but I didn't manage to find how to make it translatable.