### PR TITLE
Set target Java version of plugins to same as official Freenet build

### DIFF
--- a/ceno-freenet/build.xml
+++ b/ceno-freenet/build.xml
@@ -4,6 +4,7 @@
 <project name="ceno-plugin" default="dist" basedir=".">
 	<property name="svn.revision" value="@custom@"/>
 	<property name="source-version" value="1.5"/>
+	<property name="target-version" value="1.7"/><!-- same as Freenet build -->
 
 	<property name="build" location="build/"/>
 	<property name="build-test" location="build-test/"/>
@@ -65,7 +66,7 @@
 		<tstamp/>
 
 		<!-- FIXME: remove the debug and replace with optimize -->
-		<javac srcdir="src/plugins/CENO" destdir="${build}" debug="on" optimize="on" source="${source-version}" includeantruntime='false'>
+		<javac srcdir="src/plugins/CENO" destdir="${build}" debug="on" optimize="on" source="${source-version}" target="${target-version}" includeantruntime='false'>
 			<classpath>
 				<pathelement location="${freenet-cvs-snapshot.location}"/>
 				<pathelement location="${jetty-all.location}"/>
@@ -87,7 +88,7 @@
 		<!-- Create the time stamp -->
 		<tstamp/>
 
-		<javac srcdir="src/plugins/CENO" destdir="${build-gcj}" compiler="gcj" debug="on" optimize="on" source="${source-version}">
+		<javac srcdir="src/plugins/CENO" destdir="${build-gcj}" compiler="gcj" debug="on" optimize="on" source="${source-version}" target="${target-version}">
 			<classpath>
 				<pathelement location="${freenet-cvs-snapshot.location}"/>
 			</classpath>


### PR DESCRIPTION
This avoids issues when building CENO on a platform with a newer JDK than the one used to build or run Freenet, in particular this error reported in Freenet alerts when building CENO on JDK 8:

```
    Could not load plugin!

    The plugin CENOBridge.jar could not be loaded: unexpected error while plugin loading java.lang.UnsupportedClassVersionError: plugins/CENO/Bridge/CENOBridge : Unsupported major.minor version 52.0
```

By setting the target version to 1.7 we ensure that CENO plugins will work wherever Freenet does.
